### PR TITLE
fix(preview-page): render row elements as single line

### DIFF
--- a/src/components/preview-page.tsx
+++ b/src/components/preview-page.tsx
@@ -102,10 +102,13 @@ function renderAuthor(preview: Preview) {
     linkUrl = "https://github.com/" + user.username;
   }
   return (
-    <span title={user.username}>
+    <span
+        title={user.username}
+        className={styles["author-details"]}
+    >
       <figure key="image">
         <img
-          height='24' width='24'
+          height='18' width='18'
           src={imageUrl}
           onLoad={evt => evt.currentTarget.classList.add("visible")}
         />

--- a/styles.module.scss
+++ b/styles.module.scss
@@ -1,5 +1,4 @@
 .PipelineActivityList {
-
   .status-running {
     color: cornflowerblue;
   }
@@ -13,8 +12,6 @@
   }
 }
 
-
-
 .RepositoryList {
   .status-running {
     color: cornflowerblue;
@@ -26,5 +23,16 @@
 
   .status-failed {
     color: red;
+  }
+}
+
+.PreviewList {
+  .author-details {
+    figure {
+      display: inherit;
+      img {
+        display: inherit;
+      }
+    }
   }
 }


### PR DESCRIPTION
Cleaned up rendering of the Previews table by setting author content to be inline.

Resolves #5

Signed-off-by: Hays Clark <hays.clark@gmail.com>